### PR TITLE
add handle method for compability with Laravel 5.5

### DIFF
--- a/src/Console/Commands/ReactServe.php
+++ b/src/Console/Commands/ReactServe.php
@@ -22,11 +22,19 @@ class ReactServe extends Command
     protected $description = "Serve the application on the ReactPHP server";
 
     /**
+     * @deprecated since laravel 5.5
+     */
+    public function fire()
+    {
+        $this->handle();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return mixed
      */
-    public function fire()
+    public function handle()
     {
         $listen = $this->input->getOption('listen');
 


### PR DESCRIPTION
- Laravel Version: 5.5.0

I had checked from the latest update of Laravel the fire method used in Artisan Commands has been renamed to handle and this had causing errors when run php artisan react-serve.

### The fire Method
_Any fire methods present on your Artisan commands should be renamed to handle._
[https://laravel.com/docs/master/upgrade](url)

  php artisan react-serve --listen=tcp://127.0.0.1:8080

  [ReflectionException]                                                        
  Method LaravelReactPHP\Console\Commands\ReactServe::handle() does not exist
